### PR TITLE
Update for nightly (e5cd65)

### DIFF
--- a/core.rs
+++ b/core.rs
@@ -1,19 +1,26 @@
 #![feature(asm)]
 #![feature(lang_items)]
+#![feature(no_std)]
 
 #![no_std]
 
 use arduino::{init, delay, pinMode, digitalWrite, analogWrite, LOW, HIGH, OUTPUT};
 mod arduino;
 
+trait MarkerTrait : PhantomFn<Self> { }
+impl<T: ?Sized> MarkerTrait for T { }
+
+#[lang = "phantom_fn"]
+trait PhantomFn<A:?Sized,R:?Sized=()> { }
+
 #[lang="sized"]
-trait Sized {}
+trait Sized : MarkerTrait {}
 
 #[lang="copy"]
-trait Copy {}
+trait Copy : MarkerTrait {}
 
 #[lang="sync"]
-trait Sync {}
+trait Sync : MarkerTrait {}
 
 static PWM:u32 = 2;
 static LED:u32 = 13;


### PR DESCRIPTION
The new variance system causes compilation errors when you have empty traits such as

``` rust
#[lang = "sized"]
trait Sized {}
```

This follows the new system, but meant copying a couple more traits over from libcore. It might be worth it to consider just building libcore and linking against it or this kind of thing is going to keep coming up.

The `#![no_std]` attribute was also put behind a feature gate, so I changed that as well.

Note that the `MarkerTrait` and `PhantomFn` snipets are taken straight out of libcore.
